### PR TITLE
🐛 fix(cd): use of commit message for cf pages deploy command

### DIFF
--- a/.github/actions/deploy-cloudflare/action.yml
+++ b/.github/actions/deploy-cloudflare/action.yml
@@ -63,4 +63,5 @@ runs:
       with:
         apiToken: ${{ inputs.api_token }}
         accountId: ${{ inputs.account_id }}
-        command: pages deploy ${{ inputs.dist_path }} --project-name=${{ inputs.project_name }} --branch=${{ inputs.pr_number != '' && format('pr-{0}', inputs.pr_number) || inputs.branch }}
+        # TODO: Flag to shorten commit message to fix build fails when commit message is too long (cf https://github.com/cloudflare/workers-sdk/issues/11749)
+        command: pages deploy ${{ inputs.dist_path }} --project-name=${{ inputs.project_name }} --branch=${{ inputs.pr_number != '' && format('pr-{0}', inputs.pr_number) || inputs.branch }} --commit-message="$(git show --pretty=format:%s -s HEAD)"


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

Fixes the astrobook deployment fail by adding commit message flag on the pages deploy command to take only the first commit message instead of all the content.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: Fixes #123 -->

Fixes the #148 issue.

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/formatting changes
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🔧 Build/CI configuration change
- [ ] 🧹 Chore (other changes that don't modify src or test files)

## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] My code follows the project's code style (`just lint`)
- [x] I have run TypeScript checks (`just check`)
- [x] I have checked for unused exports/dependencies (`just knip`)
- [x] I have updated translations if needed (`just i18n-check`)
- [x] My commits follow the [Conventional Commits](CONTRIBUTING.md#commit-messages) format
- [x] My branch name follows the [Branch Naming](CONTRIBUTING.md#branch-naming) convention
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)

## Screenshots (if applicable)

<!-- If your changes affect the UI, please include screenshots -->

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### How to Test

<!-- Step-by-step instructions to test your changes -->

1. Run the astrobook deployment with changes merged to main or the comand 
2. Now it deploys correctly
3. 

## Related Issues

<!-- Link any related issues here -->
#148 